### PR TITLE
Заглушка типов

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = false

--- a/parser/mplib.lua
+++ b/parser/mplib.lua
@@ -605,6 +605,7 @@ end
 std.phr.raw_word = function(s)
 	local dsc = std.call(s, 'dsc')
 	if (dsc == nil) then
+		error("Phrase without dsc", 2)
 		dsc = ''
 	end
 	return dsc .. '|'.. (tostring(s.__ph_idx) or std.dispof(s))

--- a/parser/mplib.lua
+++ b/parser/mplib.lua
@@ -604,6 +604,9 @@ end
 -- dialogs
 std.phr.raw_word = function(s)
 	local dsc = std.call(s, 'dsc')
+	if (dsc == nil) then
+		dsc = ''
+	end
 	return dsc .. '|'.. (tostring(s.__ph_idx) or std.dispof(s))
 end
 


### PR DESCRIPTION
- Конфиг [EditorConfig](https://editorconfig.org) (табы vs пробелы)
- Заглушка типа для `raw_word` (не знаю на каком именно предмете, но в этом месте оно не находит `dsc` и падает)